### PR TITLE
Make tokens expire and ensure user passwords are hashed

### DIFF
--- a/src/main/java/de/stw/phoenix/auth/api/AuthService.java
+++ b/src/main/java/de/stw/phoenix/auth/api/AuthService.java
@@ -10,7 +10,7 @@ public interface AuthService {
 
     void invalidate(Token token);
 
-    Optional<User> findUser(String token);
+    Optional<User> findAuthenticatedUser(String token);
 
     default Token authenticate(UserAuthRequest authRequest) {
         Objects.requireNonNull(authRequest);

--- a/src/main/java/de/stw/phoenix/auth/api/PasswordEncoder.java
+++ b/src/main/java/de/stw/phoenix/auth/api/PasswordEncoder.java
@@ -1,0 +1,7 @@
+package de.stw.phoenix.auth.api;
+
+public interface PasswordEncoder {
+    String encode(CharSequence rawPassword);
+
+    boolean matches(CharSequence rawPassword, String storedHash);
+}

--- a/src/main/java/de/stw/phoenix/auth/api/Token.java
+++ b/src/main/java/de/stw/phoenix/auth/api/Token.java
@@ -1,15 +1,18 @@
 package de.stw.phoenix.auth.api;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 
 public class Token {
     private final String token;
-    private final Instant expireTime;
+    private final Instant creationTime;
+    private final Duration duration;
 
-    public Token(String token, Instant expireTime) {
+    public Token(String token, Instant creationTime, Duration duration) {
         this.token = Objects.requireNonNull(token);
-        this.expireTime = Objects.requireNonNull(expireTime);
+        this.creationTime = Objects.requireNonNull(creationTime);
+        this.duration = Objects.requireNonNull(duration);
     }
 
     public String getToken() {
@@ -17,6 +20,18 @@ public class Token {
     }
 
     public Instant getExpireTime() {
-        return expireTime;
+        return creationTime.plus(duration);
+    }
+
+    public boolean isValid(Instant current) {
+        return current.isBefore(getExpireTime()) || current.equals(getExpireTime());
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public Instant getCreationTime() {
+        return creationTime;
     }
 }

--- a/src/main/java/de/stw/phoenix/auth/impl/AuthorizationUserDetailsService.java
+++ b/src/main/java/de/stw/phoenix/auth/impl/AuthorizationUserDetailsService.java
@@ -47,7 +47,7 @@ public class AuthorizationUserDetailsService implements AuthenticationUserDetail
         final User user = Optional.ofNullable(token)
                 .map(String::valueOf)
                 .map(t -> t.replaceFirst("Bearer", "").trim())
-                .flatMap(authService::findUser)
+                .flatMap(authService::findAuthenticatedUser)
                 .orElseThrow(() -> new UsernameNotFoundException(String.format("Cannot find user with authentication token = '%s'", token)));
         final org.springframework.security.core.userdetails.User userDetails = new org.springframework.security.core.userdetails.User(
                 user.getUsername(), "password", true, true, true, true,

--- a/src/main/java/de/stw/phoenix/auth/impl/BCryptPasswordEncoder.java
+++ b/src/main/java/de/stw/phoenix/auth/impl/BCryptPasswordEncoder.java
@@ -1,0 +1,32 @@
+package de.stw.phoenix.auth.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import de.stw.phoenix.auth.api.PasswordEncoder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BCryptPasswordEncoder implements PasswordEncoder {
+
+    private final org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder delegate;
+
+    public BCryptPasswordEncoder(@Value("${de.subterranwars.auth.bcrypt.strength | 10}") int strength) {
+        this.delegate = new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder(
+                org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder.BCryptVersion.$2Y, strength);
+    }
+
+    @VisibleForTesting
+    public BCryptPasswordEncoder() {
+        this(10);
+    }
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return delegate.encode(rawPassword);
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String storedHash) {
+        return delegate.matches(rawPassword, storedHash);
+    }
+}

--- a/src/main/java/de/stw/phoenix/auth/impl/DefaultAuthService.java
+++ b/src/main/java/de/stw/phoenix/auth/impl/DefaultAuthService.java
@@ -1,5 +1,6 @@
 package de.stw.phoenix.auth.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import de.stw.phoenix.auth.api.AuthService;
 import de.stw.phoenix.auth.api.Token;
@@ -50,8 +51,8 @@ public class DefaultAuthService implements AuthService {
 
     @Override
     public void invalidate(Token token) {
-        tokenUserMap.remove(token.getToken());
-        userTokenMap.remove(token);
+        final String user = tokenUserMap.remove(token.getToken());
+        userTokenMap.remove(user);
     }
 
     @Override
@@ -61,7 +62,8 @@ public class DefaultAuthService implements AuthService {
         return user;
     }
 
-    private Optional<Token> findToken(String username) {
+    @VisibleForTesting
+    protected Optional<Token> findToken(String username) {
         return Optional.ofNullable(userTokenMap.get(username));
     }
 

--- a/src/main/java/de/stw/phoenix/auth/impl/DefaultAuthService.java
+++ b/src/main/java/de/stw/phoenix/auth/impl/DefaultAuthService.java
@@ -7,6 +7,7 @@ import de.stw.phoenix.auth.api.Token;
 import de.stw.phoenix.user.api.User;
 import de.stw.phoenix.user.api.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 
@@ -21,12 +22,24 @@ import java.util.UUID;
 public class DefaultAuthService implements AuthService {
 
     private final UserRepository userRepository;
+
+    // username => token
     private final Map<String, Token> userTokenMap = Maps.newConcurrentMap();
+
+    // token => username
     private final Map<String, String> tokenUserMap = Maps.newConcurrentMap();
+    private final Duration tokenExpiration;
 
     @Autowired
-    public DefaultAuthService(UserRepository userRepository) {
+    public DefaultAuthService(final UserRepository userRepository,
+                              @Value("${de.subterranwars.auth.token.expirationInHours}") int expirationInHours) {
+        this(userRepository, Duration.ofHours(expirationInHours));
+    }
+
+    @VisibleForTesting
+    protected DefaultAuthService(UserRepository userRepository, Duration tokenExpiration) {
         this.userRepository = Objects.requireNonNull(userRepository);
+        this.tokenExpiration = Objects.requireNonNull(tokenExpiration);
     }
 
     // TODO MVR implement properly
@@ -40,7 +53,7 @@ public class DefaultAuthService implements AuthService {
             if (password.equals(userOptional.get().getPassword())) {
                 final String token = UUID.randomUUID().toString();
                 // TODO dynamic expiration (maybe make configurable)
-                final Token newToken = new Token(token, Instant.now().plus(Duration.ofDays(1)));
+                final Token newToken = new Token(token, Instant.now(), tokenExpiration);
                 userTokenMap.put(username, newToken);
                 tokenUserMap.put(token, username);
                 return newToken;
@@ -56,9 +69,19 @@ public class DefaultAuthService implements AuthService {
     }
 
     @Override
-    public Optional<User> findUser(String token) {
-        Optional<User> user = Optional.ofNullable(tokenUserMap.get(token))
-                .flatMap(username -> userRepository.find(username));
+    public Optional<User> findAuthenticatedUser(final String tokenString) {
+        final Optional<User> user = userTokenMap.values().stream()
+                .filter(t -> Objects.equals(t.getToken(), tokenString))
+                .findAny()
+                .map(token -> {
+                    // Ensure that when fetching the token it is still valid
+                    if (!token.isValid(Instant.now())) {
+                        invalidate(token); // invalidate if no longer valid
+                    }
+                    // token is valid, fetch the User
+                    return Optional.ofNullable(tokenUserMap.get(tokenString))
+                            .flatMap(username -> userRepository.find(username));
+                }).orElse(Optional.empty());
         return user;
     }
 

--- a/src/main/java/de/stw/phoenix/user/api/User.java
+++ b/src/main/java/de/stw/phoenix/user/api/User.java
@@ -1,6 +1,8 @@
 package de.stw.phoenix.user.api;
 
 import com.google.common.base.Preconditions;
+import de.stw.phoenix.user.api.password.Password;
+import de.stw.phoenix.user.api.password.UnsecurePassword;
 
 import java.util.Objects;
 
@@ -8,14 +10,21 @@ public class User {
     private long id;
     private String username;
     private String email;
-    private String password;
+    private Password password;
 
     private User(Builder builder) {
         Objects.requireNonNull(builder);
         this.id = builder.id;
-        this.username = builder.username;
-        this.email = builder.email;
-        this.password = builder.password;
+        this.username = Objects.requireNonNull(builder.username);
+        this.email = Objects.requireNonNull(builder.email);
+        this.password = Objects.requireNonNull(builder.password);
+    }
+
+    public static Builder builder(final User user) {
+        return builder()
+                .id(user.id)
+                .username(user.username)
+                .email(user.email).password(user.password);
     }
 
     public long getId() {
@@ -30,7 +39,7 @@ public class User {
         return email;
     }
 
-    public String getPassword() {
+    public Password getPassword() {
         return password;
     }
 
@@ -42,7 +51,7 @@ public class User {
         private long id;
         private String username;
         private String email;
-        private String password;
+        private Password password;
 
 
         public Builder id(long id) {
@@ -64,6 +73,10 @@ public class User {
         }
 
         public Builder password(String password) {
+            return password(new UnsecurePassword(password));
+        }
+
+        public Builder password(Password password) {
             Objects.requireNonNull(password);
             this.password = password;
             return this;

--- a/src/main/java/de/stw/phoenix/user/api/UserRepository.java
+++ b/src/main/java/de/stw/phoenix/user/api/UserRepository.java
@@ -6,9 +6,11 @@ import java.util.Optional;
 public interface UserRepository {
     Optional<User> find(String userName);
 
-    void save(User newUser);
+    User save(User newUser);
 
     long count();
 
     List<User> findAll();
+
+    Optional<User> lookup(String username, String password);
 }

--- a/src/main/java/de/stw/phoenix/user/api/UserService.java
+++ b/src/main/java/de/stw/phoenix/user/api/UserService.java
@@ -4,4 +4,6 @@ import de.stw.phoenix.user.rest.UserCreateRequest;
 
 public interface UserService {
     void create(UserCreateRequest userCreateRequest);
+
+    User save(User user);
 }

--- a/src/main/java/de/stw/phoenix/user/api/password/HashedPassword.java
+++ b/src/main/java/de/stw/phoenix/user/api/password/HashedPassword.java
@@ -1,0 +1,22 @@
+package de.stw.phoenix.user.api.password;
+
+import java.util.Objects;
+
+public class HashedPassword implements Password {
+
+    private final String hash;
+
+    public HashedPassword(String hash) {
+        this.hash = Objects.requireNonNull(hash);
+    }
+
+    @Override
+    public boolean isEncoded() {
+        return true;
+    }
+
+    @Override
+    public String getValue() {
+        return hash;
+    }
+}

--- a/src/main/java/de/stw/phoenix/user/api/password/Password.java
+++ b/src/main/java/de/stw/phoenix/user/api/password/Password.java
@@ -1,0 +1,10 @@
+package de.stw.phoenix.user.api.password;
+
+/**
+ * Interface to allow handling of unhashed (unsecure) passwords but ensure they
+ * are actually hashed (secure) before persisting.
+ */
+public interface Password {
+    boolean isEncoded();
+    String getValue();
+}

--- a/src/main/java/de/stw/phoenix/user/api/password/UnsecurePassword.java
+++ b/src/main/java/de/stw/phoenix/user/api/password/UnsecurePassword.java
@@ -1,0 +1,22 @@
+package de.stw.phoenix.user.api.password;
+
+import java.util.Objects;
+
+public class UnsecurePassword implements Password {
+
+    private final String password;
+
+    public UnsecurePassword(String password) {
+        this.password = Objects.requireNonNull(password);
+    }
+
+    @Override
+    public boolean isEncoded() {
+        return false;
+    }
+
+    @Override
+    public String getValue() {
+        return password;
+    }
+}

--- a/src/main/java/de/stw/phoenix/user/impl/DefaultUserService.java
+++ b/src/main/java/de/stw/phoenix/user/impl/DefaultUserService.java
@@ -1,5 +1,6 @@
 package de.stw.phoenix.user.impl;
 
+import de.stw.phoenix.auth.api.PasswordEncoder;
 import de.stw.phoenix.user.api.User;
 import de.stw.phoenix.user.api.UserRepository;
 import de.stw.phoenix.user.api.UserService;
@@ -7,24 +8,34 @@ import de.stw.phoenix.user.rest.UserCreateRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
+
 @Service
 public class DefaultUserService implements UserService {
 
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
     @Autowired
-    private UserRepository userRepository;
+    public DefaultUserService(final UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = Objects.requireNonNull(userRepository);
+        this.passwordEncoder = Objects.requireNonNull(passwordEncoder);
+    }
 
     @Override
     public void create(UserCreateRequest userCreateRequest) {
-        if (userRepository.find(userCreateRequest.getUsername()).isPresent()) {
-            throw new IllegalArgumentException("User already exists");
-        }
-        // TODO MVR should be registered as a player as well
         final User newUser = User.builder()
                 .id(userRepository.count() + 1)
                 .username(userCreateRequest.getUsername())
                 .email(userCreateRequest.getEmail())
                 .password(userCreateRequest.getPassword()).build();
-        userRepository.save(newUser);
+        save(newUser);
+    }
+
+    // TODO MVR should be registered as a player as well
+    @Override
+    public User save(User user) {
+        return userRepository.save(user);
     }
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 logging.level.de.stw=DEBUG
 server.port=8081
+
+de.subterranwars.auth.token.expirationInHours=24

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,4 @@ logging.level.de.stw=DEBUG
 server.port=8081
 
 de.subterranwars.auth.token.expirationInHours=24
+de.subterranwars.auth.bcrypt.strength=12

--- a/src/test/java/de/stw/phoenix/auth/api/TokenTest.java
+++ b/src/test/java/de/stw/phoenix/auth/api/TokenTest.java
@@ -1,0 +1,26 @@
+package de.stw.phoenix.auth.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class TokenTest {
+
+    @Test
+    public void verifyExpiration() {
+        final Instant now = Instant.now();
+        final Token token = new Token("token", now, Duration.ofHours(1));
+
+        // Verify that the token is at least one hour valid
+        for (int i=0; i<=60; i++) {
+            assertThat(token.isValid(now.plus(Duration.ofMinutes(i))), is(true));
+        }
+        // Now it should be invalid
+        assertThat(token.isValid(now.plus(Duration.ofMinutes(60).plusMillis(1))), is(false));
+    }
+
+}

--- a/src/test/java/de/stw/phoenix/auth/impl/DefaultAuthServiceTest.java
+++ b/src/test/java/de/stw/phoenix/auth/impl/DefaultAuthServiceTest.java
@@ -55,7 +55,7 @@ class DefaultAuthServiceTest {
         assertThat(user.isPresent(), is(true));
 
         // Wait for token to be expired
-        Thread.sleep(10 * 1000);
+        Thread.sleep(12 * 1000);
 
         // Verify lookup now does not work as token is expired
         assertThat(authService.findAuthenticatedUser(token.getToken()).isPresent(), is(false));

--- a/src/test/java/de/stw/phoenix/auth/impl/DefaultAuthServiceTest.java
+++ b/src/test/java/de/stw/phoenix/auth/impl/DefaultAuthServiceTest.java
@@ -26,7 +26,7 @@ class DefaultAuthServiceTest {
     @BeforeEach
     public void before() {
         final User user = User.builder().id(1).username("test").password("test").email("test@subterranwars.de").build();
-        userRepository = new DefaultUserRepository();
+        userRepository = new DefaultUserRepository(new BCryptPasswordEncoder(10));
         userRepository.save(user);
         authService = new DefaultAuthService(userRepository, Duration.ofSeconds(10));
     }

--- a/src/test/java/de/stw/phoenix/auth/impl/DefaultAuthServiceTest.java
+++ b/src/test/java/de/stw/phoenix/auth/impl/DefaultAuthServiceTest.java
@@ -1,15 +1,73 @@
 package de.stw.phoenix.auth.impl;
 
-import de.stw.phoenix.auth.api.AuthService;
+import de.stw.phoenix.auth.api.Token;
+import de.stw.phoenix.user.api.User;
+import de.stw.phoenix.user.api.UserRepository;
 import de.stw.phoenix.user.impl.DefaultUserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.BadCredentialsException;
 
-// TODO MVR implement me
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 class DefaultAuthServiceTest {
+
+    private UserRepository userRepository;
+    private DefaultAuthService authService;
+
+    @BeforeEach
+    public void before() {
+        final User user = User.builder().id(1).username("test").password("test").email("test@subterranwars.de").build();
+        userRepository = new DefaultUserRepository();
+        userRepository.save(user);
+        authService = new DefaultAuthService(userRepository);
+    }
 
     @Test
     public void verifyAuth() {
-        final AuthService authService = new DefaultAuthService(new DefaultUserRepository());
+        final Token token = authService.authenticate("test", "test");
+        assertThat(token, notNullValue());
+        assertThat(token.isValid(), is(true));
+        assertThat(token.getToken(), notNullValue());
+
+        final Optional<User> user = authService.findUser(token.getToken());
+        assertThat(user.isPresent(), is(true));
+        assertThat(user.get().getUsername(), is("test"));
+    }
+
+    @Test
+    public void verifyInvalidCredentials() {
+        assertThrows(BadCredentialsException.class, () -> authService.authenticate("test", "test1234"));
+    }
+
+    @Test
+    public void verifyInvalidate() {
+        final Token token = authService.authenticate("test", "test");
+        authService.invalidate(token);
+        assertThat(authService.findUser(token.getToken()).isPresent(), is(false));
+        assertThat(authService.findToken("test").isPresent(), is(false));
+    }
+
+    @Test
+    public void verifyInvalidateOnReauth() {
+        final Token token = authService.authenticate("test", "test");
+        final Token anotherToken = authService.authenticate("test", "test");
+        assertThat(token, notNullValue());
+        assertThat(anotherToken, notNullValue());
+        assertThat(token.getToken(), not(is(anotherToken.getToken())));
+
+        // Ensure it was invalidated
+        assertThat(authService.findUser(token.getToken()).isPresent(), is(false));
+        assertThat(authService.findUser(anotherToken.getToken()).isPresent(), is(true));
+
+        // Ensure mapping for user updates properly
+        assertThat(authService.findToken("test").get(), is(anotherToken));
     }
 
 }

--- a/src/test/java/de/stw/phoenix/user/impl/DefaultUserRepositoryTest.java
+++ b/src/test/java/de/stw/phoenix/user/impl/DefaultUserRepositoryTest.java
@@ -1,0 +1,30 @@
+package de.stw.phoenix.user.impl;
+
+import de.stw.phoenix.auth.impl.BCryptPasswordEncoder;
+import de.stw.phoenix.user.api.User;
+import de.stw.phoenix.user.api.UserRepository;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class DefaultUserRepositoryTest {
+
+    private UserRepository userRepository;
+
+    @BeforeEach
+    public void before() {
+        this.userRepository = new DefaultUserRepository(new BCryptPasswordEncoder());
+    }
+
+    @Test
+    public void verifyDoesNotPersistUnsecurePasswords() {
+        User user = User.builder().id(1).username("test").password("test").email("test@subterranwars.de").build();
+        assertThat(user.getPassword().getValue(), Matchers.is("test"));
+
+        user = userRepository.save(user);
+        assertThat(user.getPassword().getValue(), Matchers.not(Matchers.is("test")));
+    }
+
+}


### PR DESCRIPTION
Here we invalidate tokens after a (configurable) time period, as well as persist password encoded using bcrypt.